### PR TITLE
Add Mollie icons to payment methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "require": {
     "magento/framework": "*",
-    "hyva-themes/magento2-hyva-checkout": "*",
+    "hyva-themes/magento2-hyva-checkout": "^1.0.5|^1.1",
     "mollie/magento2": "*"
   },
   "autoload": {

--- a/src/Mollie_HyvaCheckout/Plugin/PopulateIconData.php
+++ b/src/Mollie_HyvaCheckout/Plugin/PopulateIconData.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Mollie\HyvaCheckout\Plugin;
+
+use Hyva\Checkout\Model\MethodMetaDataInterface;
+use \Mollie\Payment\Helper\General as MollieHelper;
+
+class PopulateIconData
+{
+    private string $iconLibraryPathPrefix;
+    private MollieHelper $mollieHelper;
+
+    public function __construct(string $iconLibraryPathPrefix, MollieHelper $mollieHelper)
+    {
+        $this->iconLibraryPathPrefix = $iconLibraryPathPrefix;
+        $this->mollieHelper = $mollieHelper;
+    }
+
+    public function beforeRenderIcon(MethodMetaDataInterface $subject): void
+    {
+        if (!$this->mollieHelper->useImage()) {
+            return;
+        }
+
+        $methodCode = $subject->getMethod()->getCode();
+        if (!$this->isMollieMethod($methodCode)) {
+            return;
+        }
+
+        $paymentIconPath = $this->getPaymentIconPath($methodCode);
+
+        $subject->setData(MethodMetaDataInterface::ICON, [
+            'svg' => $paymentIconPath
+        ]);
+    }
+
+    private function isMollieMethod(string $methodCode): bool
+    {
+        return strpos($methodCode, 'mollie_methods_') === 0;
+    }
+
+    private function getPaymentIconPath(string $methodCode): string
+    {
+        return $this->iconLibraryPathPrefix . '/' . str_replace('mollie_methods_', '', $methodCode);
+    }
+}

--- a/src/Mollie_HyvaCheckout/Plugin/RenderPaymentMethodIcons.php
+++ b/src/Mollie_HyvaCheckout/Plugin/RenderPaymentMethodIcons.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Mollie\HyvaCheckout\Plugin;
+
+use Hyva\Checkout\Model\MethodMetaData;
+
+class RenderPaymentMethodIcons
+{
+    /**
+     * Mollie payments do not have meta-data icons, so we need to make sure the icons are rendered without the
+     * meta-data being set. The actual data will be populated by the PopulateIconData plugin.
+     * @see \Mollie\HyvaCheckout\Plugin\PopulateIconData
+     */
+    public function afterCanRenderIcon(MethodMetaData $subject, $result)
+    {
+        if (strpos($subject->getMethod()->getCode(), 'mollie_methods_') === 0) {
+            return true;
+        }
+
+        return $result;
+    }
+}

--- a/src/Mollie_HyvaCheckout/Plugin/RenderPaymentMethodIcons.php
+++ b/src/Mollie_HyvaCheckout/Plugin/RenderPaymentMethodIcons.php
@@ -3,9 +3,17 @@
 namespace Mollie\HyvaCheckout\Plugin;
 
 use Hyva\Checkout\Model\MethodMetaData;
+use Mollie\Payment\Helper\General as MollieHelper;
 
 class RenderPaymentMethodIcons
 {
+    private MollieHelper $mollieHelper;
+
+    public function __construct(MollieHelper $mollieHelper)
+    {
+        $this->mollieHelper = $mollieHelper;
+    }
+
     /**
      * Mollie payments do not have meta-data icons, so we need to make sure the icons are rendered without the
      * meta-data being set. The actual data will be populated by the PopulateIconData plugin.
@@ -13,6 +21,10 @@ class RenderPaymentMethodIcons
      */
     public function afterCanRenderIcon(MethodMetaData $subject, $result)
     {
+        if (!$this->mollieHelper->useImage()) {
+            return $result;
+        }
+
         if (strpos($subject->getMethod()->getCode(), 'mollie_methods_') === 0) {
             return true;
         }

--- a/src/Mollie_HyvaCheckout/etc/frontend/di.xml
+++ b/src/Mollie_HyvaCheckout/etc/frontend/di.xml
@@ -40,4 +40,29 @@
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
+
+    <!-- Configure the icon library path prefix for the Hyva Checkout SVG icon renderer -->
+    <type name="Hyva\Theme\ViewModel\SvgIcons">
+        <arguments>
+            <argument name="pathPrefixMapping" xsi:type="array">
+                <item name="mollie_payments" xsi:type="string">Mollie_Payment::images/methods</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Mollie\HyvaCheckout\Plugin\PopulateIconData">
+        <arguments>
+            <!-- Change the iconLibraryPathPrefix to use a different icon library -->
+            <argument name="iconLibraryPathPrefix" xsi:type="string">mollie_payments</argument>
+        </arguments>
+    </type>
+
+    <!-- Icon renderer plugins -->
+    <type name="Hyva\Checkout\Model\MethodMetaData">
+        <plugin sortOrder="1" name="mollie_hyva_checkout_set_can_render_icon"
+                type="Mollie\HyvaCheckout\Plugin\RenderPaymentMethodIcons"/>
+    </type>
+    <type name="Hyva\Checkout\Model\MethodMetaDataInterface">
+        <plugin sortOrder="1" name="mollie_hyva_checkout_popuplate_icon_data"
+                type="Mollie\HyvaCheckout\Plugin\PopulateIconData"/>
+    </type>
 </config>


### PR DESCRIPTION
Related issue #1 

### Screenshot
<img width="1604" alt="CleanShot 2023-07-11 at 21 18 44@2x" src="https://github.com/mollie/magento2-hyva-checkout/assets/14849044/8a1d76b1-b0bf-4969-a5f4-2e02ab77aa75">
