### PR TITLE
Add title attribute to payment svg icon

### DIFF
--- a/src/Mollie_HyvaCheckout/Plugin/PopulateIconData.php
+++ b/src/Mollie_HyvaCheckout/Plugin/PopulateIconData.php
@@ -22,15 +22,19 @@ class PopulateIconData
             return;
         }
 
-        $methodCode = $subject->getMethod()->getCode();
-        if (!$this->isMollieMethod($methodCode)) {
+        $method = $subject->getMethod();
+        if (!$this->isMollieMethod($method->getCode())) {
             return;
         }
 
-        $paymentIconPath = $this->getPaymentIconPath($methodCode);
+        $paymentIconPath = $this->getPaymentIconPath($method->getCode());
 
         $subject->setData(MethodMetaDataInterface::ICON, [
-            'svg' => $paymentIconPath
+            'svg' => $paymentIconPath,
+            'attributes' => [
+                'title' => $method->getTitle()
+            ]
+            
         ]);
     }
 


### PR DESCRIPTION
Hiya, this PR will fill the title attribute of the payment icon with the payment method name, by default/currently the title attribute is the method code. Payment method name looks cleaner in my opinion when users hover payment methods.

Before:
![mollie_before_title](https://github.com/mollie/magento2-hyva-checkout/assets/13732765/3a7821c7-55df-427a-83dd-ed2fa389436b)

After:
![mollie_after_title](https://github.com/mollie/magento2-hyva-checkout/assets/13732765/b8cb8497-0282-41ee-b3b4-42fa6cf6008e)