### PR TITLE
Hyva checkout 1.1.13 compatibility

### DIFF
--- a/src/Mollie_HyvaCheckout/Service/PlaceOrderService.php
+++ b/src/Mollie_HyvaCheckout/Service/PlaceOrderService.php
@@ -6,6 +6,8 @@
 
 namespace Mollie\HyvaCheckout\Service;
 
+use Hyva\Checkout\Model\Magewire\Component\EvaluationResultFactory;
+use Hyva\Checkout\Model\Magewire\Component\EvaluationResultInterface;
 use Hyva\Checkout\Model\Magewire\Payment\AbstractPlaceOrderService;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Message\Manager;
@@ -48,7 +50,17 @@ class PlaceOrderService extends AbstractPlaceOrderService
         $this->redirectUrl = $redirectUrl;
     }
 
+    public function evaluateCompletion(EvaluationResultFactory $resultFactory, ?int $orderId = null): EvaluationResultInterface
+    {
+        return $resultFactory->createSuccess();
+    }
+    
     public function canPlaceOrder(): bool
+    {
+        return true;
+    }
+
+    public function canRedirect(): bool
     {
         return true;
     }


### PR DESCRIPTION
Possible fix for https://github.com/mollie/magento2-hyva-checkout/issues/17. Needs further testing! On the latest version of the Hyvä checkout (1.1.13) it seems to work correctly. I didn't check (yet) what it does on older versions.