### PR TITLE
Add google pay to the list of available methods

### DIFF
--- a/src/Mollie_HyvaCheckout/etc/frontend/di.xml
+++ b/src/Mollie_HyvaCheckout/etc/frontend/di.xml
@@ -21,6 +21,7 @@
                 <item name="mollie_methods_directdebit" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>
                 <item name="mollie_methods_eps" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>
                 <item name="mollie_methods_giftcard" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>
+                <item name="mollie_methods_googlepay" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>
                 <item name="mollie_methods_ideal" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>
                 <item name="mollie_methods_in3" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>
                 <item name="mollie_methods_kbc" xsi:type="object">Mollie\HyvaCheckout\Service\PlaceOrderService</item>


### PR DESCRIPTION
When paying on Hyva Checkout with google pay right now you end up on the success page without payment redirect and without any payment.
Seems like the method was forgotten and not applied to the list.