### PR TITLE
Fix failed payment redirect URLs for Hyva Checkout

### DIFF
--- a/src/Mollie_HyvaCheckout/Plugin/Mollie/Service/Order/RedirectOnErrorPlugin.php
+++ b/src/Mollie_HyvaCheckout/Plugin/Mollie/Service/Order/RedirectOnErrorPlugin.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\HyvaCheckout\Plugin\Mollie\Service\Order;
+
+use Magento\Framework\UrlInterface;
+use Mollie\Payment\Config;
+use Mollie\Payment\Model\Adminhtml\Source\RedirectUserWhenTransactionFails;
+use Mollie\Payment\Service\Order\RedirectOnError;
+
+class RedirectOnErrorPlugin
+{
+    private Config $config;
+    private UrlInterface $urlBuilder;
+
+    public function __construct(
+        Config $config,
+        UrlInterface $urlBuilder
+    ) {
+        $this->config = $config;
+        $this->urlBuilder = $urlBuilder;
+    }
+
+    /**
+     * Replace hash-based checkout URLs with Hyva Checkout step URLs.
+     *
+     * The base Mollie module returns URLs like /checkout/#payment which work for
+     * standard Magento checkout (hash-based routing), but Hyva Checkout uses
+     * URL-based step navigation: /checkout/index/index/step/payment/
+     */
+    public function afterGetUrl(RedirectOnError $subject, string $result): string
+    {
+        $redirectTo = $this->config->redirectWhenTransactionFailsTo();
+
+        if ($redirectTo === RedirectUserWhenTransactionFails::REDIRECT_TO_CHECKOUT_SHIPPING) {
+            return $this->urlBuilder->getUrl('checkout', ['step' => 'shipping']);
+        }
+
+        if ($redirectTo === RedirectUserWhenTransactionFails::REDIRECT_TO_CHECKOUT_PAYMENT) {
+            return $this->urlBuilder->getUrl('checkout', ['step' => 'payment']);
+        }
+
+        return $result;
+    }
+}

--- a/src/Mollie_HyvaCheckout/etc/frontend/di.xml
+++ b/src/Mollie_HyvaCheckout/etc/frontend/di.xml
@@ -59,4 +59,10 @@
     <type name="Mollie\Payment\Model\Methods\CreditcardVault">
         <plugin name="mollie_hyva_change_vault_title" type="Mollie\HyvaCheckout\Plugin\Mollie\Model\Methods\ChangeVaultTitle" />
     </type>
+
+    <!-- Replace hash-based checkout URLs with Hyva Checkout step URLs for failed payment redirects -->
+    <type name="Mollie\Payment\Service\Order\RedirectOnError">
+        <plugin name="mollie_hyva_checkout_redirect_on_error"
+                type="Mollie\HyvaCheckout\Plugin\Mollie\Service\Order\RedirectOnErrorPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
## Problem

When the Mollie admin setting **"Redirect user when transaction fails"** is configured to redirect to the payment or shipping step, the base `mollie/magento2` module constructs URLs using hash fragments:

- Shipping: `/checkout/`
- Payment: `/checkout/#payment`

This works for standard Magento checkout (which uses hash-based routing), but **Hyva Checkout uses URL-based step navigation**:

- Shipping: `/checkout/index/index/step/shipping/`
- Payment: `/checkout/index/index/step/payment/`

As a result, customers returning from a failed Mollie payment are redirected to the first checkout step instead of the configured step.

## Solution

Add an after plugin on `Mollie\Payment\Service\Order\RedirectOnError::getUrl()` (frontend scope) that replaces the hash-based URLs with the correct Hyva Checkout step URLs.

The plugin reads the same configuration value and constructs proper URLs using `$urlBuilder->getUrl('checkout', ['step' => 'payment'])`, which the Hyva Checkout controller (`Hyva\Checkout\Controller\Index\Index`) understands via `$this->getRequest()->getParam('step')`.

| Config value | Before (broken) | After (fixed) |
|---|---|---|
| Redirect to shipping | `/checkout/` | `/checkout/index/index/step/shipping/` |
| Redirect to payment | `/checkout/#payment` | `/checkout/index/index/step/payment/` |
| Redirect to cart | `/checkout/cart` | `/checkout/cart` (unchanged) |

Since this plugin lives in the Hyva compatibility module, it only activates when `mollie/magento2-hyva-checkout` is installed — standard Magento checkout behavior is unaffected.