### PR TITLE
observer: add missing check if module is enabled

### DIFF
--- a/src/Mollie_HyvaCheckout/Observer/SalesQuoteCollectTotalsBefore/SetDefaultSelectedPaymentMethod.php
+++ b/src/Mollie_HyvaCheckout/Observer/SalesQuoteCollectTotalsBefore/SetDefaultSelectedPaymentMethod.php
@@ -50,6 +50,10 @@ class SetDefaultSelectedPaymentMethod implements ObserverInterface
         /** @var Quote $quote */
         $quote = $observer->getData('quote');
 
+        if (!$this->config->isModuleEnabled((int)$quote->getStoreId())) {
+            return;
+        }
+
         // Don't override if the quote isn't available yet or if a payment method is already set.
         if (!$quote->getId() ||
             !$this->config->getApiKey((int)$quote->getStoreId()) ||


### PR DESCRIPTION
if the store does have to store-views/websites, and only one of them is using Mollie Payments, the following errors got logged in the mollie.log if the (disabled) website does not have a configured api-key 

```
[2026-01-22T22:03:25.269386+00:00] mollie-logger.ERROR: error: Mollie API key not set (test modus) [] []
[2026-01-22T22:03:25.269441+00:00] mollie-logger.ERROR: error: Mollie set to test modus, but API key does not start with "test_" [] []
```

This PR will add the required check before trying to get the API key form the configuration.

